### PR TITLE
Suppression du funiculaire de Montmartre

### DIFF
--- a/data/stations-paris2.csv
+++ b/data/stations-paris2.csv
@@ -82,8 +82,6 @@ id,latitude,longitude,name,display_name,zone,total_lines,rail
 104,48.8434118592224,2.46481540327434,Fontenay-sous-Bois,Fontenay-sous-Bois,1,1,0
 105,48.9140567451466,2.40357633451101,Fort d'Aubervilliers,Fort d'Aubervilliers,1,1,0
 106,48.8690104279376,2.31025318089603,Franklin-Roosevelt,Franklin-Roosevelt,1,2,0
-107,48.8846961785522,2.34261028296205,Funiculaire Gare basse,Funiculaire Gare basse,1,1,0
-108,48.8855769295109,2.34254223541153,Funiculaire Gare haute,Funiculaire Gare haute,1,1,0
 109,48.9165748359832,2.29432896468706,Gabriel-Péri,Gabriel-Péri,1,1,0
 110,48.8387518213886,2.32250918622471,Gaité,Gaité,1,1,0
 111,48.8632625265005,2.41597536849996,Gallieni (Parc de Bagnolet),Gallieni (Parc de Bagnolet),1,1,0


### PR DESCRIPTION
Ses deux stations (_Funiculaire Gare basse_ et _Funiculaire Gare haute_) étaient encore dans la liste.
